### PR TITLE
Add ansible-lint and pre-commit to install list

### DIFF
--- a/.ansible/variables-example.yml
+++ b/.ansible/variables-example.yml
@@ -5,6 +5,7 @@
 apt:
   install:
     - 7zip
+    - ansible-lint
     - btrfs-progs
     - build-essential
     - cargo
@@ -46,6 +47,7 @@ apt:
     - pipenv
     - plocate  # locate, updatedb
     - poppler-utils
+    - pre-commit
     - python3-pip
     - pv
     - rename


### PR DESCRIPTION
## Summary by Sourcery

Add additional development tools to the Ansible-managed package installation list.

New Features:
- Include ansible-lint in the default apt packages installed by Ansible.
- Include pre-commit in the default apt packages installed by Ansible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added `ansible-lint` and `pre-commit` packages to the system package installation configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->