### PR TITLE
Add .aria2.conf and update dotfiles symlink configuration

### DIFF
--- a/.ansible/variables-example.yml
+++ b/.ansible/variables-example.yml
@@ -87,6 +87,7 @@ dotfiles:
     .aliasesrc_linux: true
     .aliasesrc_macos: true
     .aliasesrc_rg: true
+    .aria2.conf: true
     .bash_aliases: true
     .bash_completion: true
     .bash_exports: true
@@ -152,3 +153,9 @@ eget_packages:
 nvidia:
   cuda_toolkit: true
   cuda_toolkit_package: cuda-toolkit-13-1
+
+snap:
+  install:
+    - name: sublime-text
+      classic: true
+    - telegram-desktop

--- a/.ansible/variables-example.yml
+++ b/.ansible/variables-example.yml
@@ -153,9 +153,3 @@ eget_packages:
 nvidia:
   cuda_toolkit: true
   cuda_toolkit_package: cuda-toolkit-13-1
-
-snap:
-  install:
-    - name: sublime-text
-      classic: true
-    - telegram-desktop

--- a/.aria2.conf
+++ b/.aria2.conf
@@ -1,0 +1,9 @@
+connect-timeout=10
+file-allocation=falloc # uses SetFileValidData function to allocate disk space without filling zero.
+max-connection-per-server=16
+max-file-not-found=10
+max-tries=10
+min-split-size=1M
+retry-wait=10
+split=16
+timeout=10


### PR DESCRIPTION
## Summary by Sourcery

Add a new aria2 configuration file and include it in the managed dotfiles set.

New Features:
- Introduce an .aria2.conf configuration file with default download and connection settings.
- Enable symlinking of the new .aria2.conf file via the dotfiles Ansible variables configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced download manager configuration optimizing connection stability with 10-second timeouts, managing concurrent transfers with 16 simultaneous connections, enabling download splitting across 16 parts with 1M minimum size, and configuring retry limits to 10 attempts
  * Integrated new configuration into dotfiles management system for automatic home directory setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->