### PR TITLE
Add Ethereum installation support

### DIFF
--- a/.ansible/README.md
+++ b/.ansible/README.md
@@ -34,6 +34,7 @@ You can use tags to run specific parts of the playbook using the `--tags` flag.
 | `cuda` | Specific tasks for CUDA Toolkit. |
 | `dotfiles` | Manages symlinks for dotfiles in your home directory. |
 | `eget` | Installs `eget` and configured binary packages. |
+| `ethereum` | Installs Ethereum tools from the official Ethereum PPA. |
 | `install` | Installs the list of packages defined in `apt.install` and `eget` packages. |
 | `nvidia` | Handles NVIDIA/CUDA related installations. |
 | `protonvpn` | Installs Proton VPN app from the official Proton APT repository. |
@@ -58,8 +59,9 @@ The `setup-linux.yml` playbook performs the following operations:
 4. **VS Code**: Adds the Microsoft repository and installs Visual Studio Code.
 5. **Brave Browser**: Adds the Brave repository and installs the browser.
 6. **Proton VPN**: Adds the official Proton VPN repository and installs the GUI app.
-7. **Eget**: Installs the `eget` binary and a set of useful CLI tools to `~/.local/bin`.
-8. **Dotfiles**: Symlinks configuration files from this repository into your `$HOME`.
+7. **Ethereum**: Adds the official Ethereum PPA and installs the `ethereum` package.
+8. **Eget**: Installs the `eget` binary and a set of useful CLI tools to `~/.local/bin`.
+9. **Dotfiles**: Symlinks configuration files from this repository into your `$HOME`.
 
 ### Note on Dotfiles Conflicts
 

--- a/.ansible/playbooks/setup-linux.yml
+++ b/.ansible/playbooks/setup-linux.yml
@@ -57,6 +57,12 @@
       become: true
       tags: [apt, mega]
 
+    - name: Import Ethereum installation tasks
+      ansible.builtin.import_tasks: tasks/apt-release-ethereum.yml
+      when: (apt.releases.ethereum | default(false)) if apt.releases is defined else false
+      become: true
+      tags: [apt, ethereum]
+
     - name: Import eget installation tasks
       ansible.builtin.import_tasks: tasks/eget.yml
       when: eget | default(false) | bool

--- a/.ansible/playbooks/tasks/apt-release-ethereum.yml
+++ b/.ansible/playbooks/tasks/apt-release-ethereum.yml
@@ -1,0 +1,12 @@
+---
+- name: Add Ethereum PPA repository
+  ansible.builtin.apt_repository:
+    repo: ppa:ethereum/ethereum
+    state: present
+    update_cache: true
+
+- name: Install Ethereum package
+  ansible.builtin.apt:
+    name: ethereum
+    state: present
+    update_cache: true

--- a/.ansible/variables-example.yml
+++ b/.ansible/variables-example.yml
@@ -75,6 +75,7 @@ apt:
   releases:
     brave: true
     code: true
+    ethereum: true  # For geth, clef, devp2p, abigen, bootnode, evm and rlpdump (ethereum/go-ethereum).
     mega: true  # MEGA CMD and Desktop App (https://mega.io/desktop & https://mega.io/cmd)
     protonvpn: true
   upgrade: true


### PR DESCRIPTION
## Summary by Sourcery

Add optional Ethereum tooling installation to the Linux setup playbook via the official Ethereum PPA.

New Features:
- Introduce an `ethereum` tag and tasks to add the official Ethereum PPA and install the `ethereum` package during Linux setup.

Documentation:
- Document the new `ethereum` tag and describe Ethereum tooling installation in the setup-linux playbook overview.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Ethereum installation support to Linux setup configuration, allowing users to enable Ethereum package installation via apt.

* **Documentation**
  * Updated setup documentation to include new Ethereum tag and added Ethereum installation step to tasks overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->