### PR TITLE
Add yt-dlp to the list of packages

### DIFF
--- a/.ansible/playbooks/tasks/eget.yml
+++ b/.ansible/playbooks/tasks/eget.yml
@@ -80,12 +80,15 @@
     eget_package_map:
       alpha-miner: "-a .tar.gz --file alpha/alpha --tag v1.7.5-beta --to alpha-miner AlphaMine-Tech/alpha-miner"
       bat: >-
-        -a {{ eget_arch }}-unknown-linux-{{ 'gnu' if eget_arch == 'x86_64' else 'musl' }}
+        -a {{ 'aarch64' if eget_arch == 'arm64' else eget_arch }}
+        -unknown-linux-{{ 'gnu' if eget_arch == 'x86_64' else 'musl' }}
         -a tar.gz sharkdp/bat
       btop: "-a btop-{{ eget_plain_arch }}-unknown-linux-musl.tar.gz aristocratos/btop"
       duf: "-a linux_{{ eget_arch }}.tar.gz muesli/duf"
       eza: "-a {{ eget_plain_arch }}-unknown-linux-gnu -a ^no_libgit -a tar.gz eza-community/eza"
-      fd: "-a {{ eget_arch }}-unknown-linux-gnu -a tar.gz sharkdp/fd"
+      fd: >-
+        -a {{ 'aarch64' if eget_arch == 'arm64' else eget_arch }}
+        -unknown-linux-gnu -a tar.gz sharkdp/fd
       jq: >-
         -a {{ 'linux64' if eget_arch == 'x86_64' else 'linux-arm64' if eget_arch == 'arm64' else 'linux-arm' }}
         jqlang/jq
@@ -104,14 +107,19 @@
           }[eget_arch]
         }}
         -a tar.gz --file rga phiresky/ripgrep-all
-      tealdeer: "-a tealdeer-linux-{{ eget_arch }}-musl -a ^sha256 dbrgn/tealdeer"
+      tealdeer: >-
+        -a tealdeer-linux-{{ 'aarch64' if eget_arch == 'arm64' else eget_arch }}
+        -musl -a ^sha256 dbrgn/tealdeer
       vale: "-a {{ 'Linux_64-bit' if eget_arch == 'x86_64' else 'Linux_arm64' }}.tar.gz errata-ai/vale"
       yq: "-a ^.tar.gz mikefarah/yq"
       yt-dlp: >-
         -a {{
-          'yt-dlp_linux' if eget_arch == 'x86_64'
-          else 'yt-dlp_linux_aarch64' if eget_arch == 'arm64'
-          else 'yt-dlp_linux_armv7l'
+          {
+            'x86_64': 'yt-dlp_linux',
+            'arm64': 'yt-dlp_linux_aarch64',
+            'aarch64': 'yt-dlp_linux_aarch64',
+            'arm': 'yt-dlp_linux_armv7l'
+          }[eget_arch]
         }} --to yt-dlp yt-dlp/yt-dlp
 
 - name: Install eget packages

--- a/.ansible/playbooks/tasks/eget.yml
+++ b/.ansible/playbooks/tasks/eget.yml
@@ -107,6 +107,12 @@
       tealdeer: "-a tealdeer-linux-{{ eget_arch }}-musl -a ^sha256 dbrgn/tealdeer"
       vale: "-a {{ 'Linux_64-bit' if eget_arch == 'x86_64' else 'Linux_arm64' }}.tar.gz errata-ai/vale"
       yq: "-a ^.tar.gz mikefarah/yq"
+      yt-dlp: >-
+        -a {{
+          'yt-dlp_linux' if eget_arch == 'x86_64'
+          else 'yt-dlp_linux_aarch64' if eget_arch == 'arm64'
+          else 'yt-dlp_linux_armv7l'
+        }} --to yt-dlp yt-dlp/yt-dlp
 
 - name: Install eget packages
   ansible.builtin.shell:

--- a/.ansible/variables-example.yml
+++ b/.ansible/variables-example.yml
@@ -67,7 +67,6 @@ apt:
     - ugrep
     - unrar
     - unzip
-    - yt-dlp
     - vim
     - vlc
     - wget
@@ -154,6 +153,7 @@ eget_packages:
   - tealdeer     # A fast tldr client written in Rust (dbrgn/tealdeer)
   - vale         # A syntax-aware linter for prose (errata-ai/vale)
   - yq           # Portable command-line YAML, JSON, XML, CSV, TOML and properties processor (mikefarah/yq)
+  - yt-dlp       # A feature-rich command-line audio/video downloader (yt-dlp/yt-dlp)
 
 nvidia:
   cuda_toolkit: true


### PR DESCRIPTION
…eget.yml

## Summary by Sourcery

Add yt-dlp to the set of tools installed via eget and update example variables to reflect this change.

New Features:
- Install yt-dlp via eget for different architectures using appropriate binaries.

Enhancements:
- Move yt-dlp from the apt package list into the eget-managed packages list in the example variables configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched yt-dlp to be installed via the external-binary installer with architecture-aware selection so the correct tarball is used and binaries are placed in a dedicated yt-dlp location.
  * Adjusted package download selectors for other tooling (bat, fd, tealdeer) to correctly handle arm64 (aarch64) filenames and select the appropriate glibc/musl variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->