### PR TITLE
Add nethermind eget package

### DIFF
--- a/.ansible/playbooks/tasks/eget.yml
+++ b/.ansible/playbooks/tasks/eget.yml
@@ -92,6 +92,7 @@
       jq: >-
         -a {{ 'linux64' if eget_arch == 'x86_64' else 'linux-arm64' if eget_arch == 'arm64' else 'linux-arm' }}
         jqlang/jq
+      nethermind: "-a linux-{{ 'x64' if eget_arch == 'x86_64' else 'arm64' }}.zip -a ^.asc NethermindEth/nethermind"
       oyster: "--tag pearl-wallet-v1.0.0 -a .tar.gz --file oyster --to oyster pearl-research-labs/pearl"
       pandoc: "-a linux-{{ 'amd64' if eget_arch == 'x86_64' else 'arm64' }}.tar.gz jgm/pandoc"
       pearld: "--tag pearl-wallet-v1.0.0 -a .tar.gz --file pearld --to pearld pearl-research-labs/pearl"

--- a/.ansible/variables-example.yml
+++ b/.ansible/variables-example.yml
@@ -144,6 +144,7 @@ eget_packages:
   - eza          # A modern, maintained replacement for 'ls' (eza-community/eza)
   - fd           # A simple, fast and user-friendly alternative to 'find' (sharkdp/fd)
   - jq           # Command-line JSON processor (jqlang/jq)
+  - nethermind   # A robust execution client for Ethereum node operators (NethermindEth/nethermind)
   - oyster       # Pearl Wallet management (pearl-research-labs/pearl)
   - pandoc       # Universal markup converter (jgm/pandoc)
   - pearld       # Pearl Full node (pearl-research-labs/pearl)


### PR DESCRIPTION
## Summary by Sourcery

Add Nethermind as an eget-installable package in the Ansible configuration.

New Features:
- Introduce support for installing the Nethermind Ethereum execution client via eget in the Ansible playbook.

Documentation:
- Document Nethermind as an available eget package in the example variables file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for deploying nethermind (Ethereum execution client) through the automated installation system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->