### PR TITLE
Add Docker installation

### DIFF
--- a/.ansible/playbooks/setup-linux.yml
+++ b/.ansible/playbooks/setup-linux.yml
@@ -39,6 +39,12 @@
       become: true
       tags: [apt, code, vscode]
 
+    - name: Import Docker installation tasks
+      ansible.builtin.import_tasks: tasks/apt-release-docker.yml
+      when: (apt.releases.docker | default(false)) if apt.releases is defined else false
+      become: true
+      tags: [apt, docker]
+
     - name: Import Brave installation tasks
       ansible.builtin.import_tasks: tasks/apt-release-brave.yml
       when: (apt.releases.brave | default(false)) if apt.releases is defined else false

--- a/.ansible/playbooks/tasks/apt-release-docker.yml
+++ b/.ansible/playbooks/tasks/apt-release-docker.yml
@@ -1,0 +1,46 @@
+---
+- name: Install dependencies for Docker
+  ansible.builtin.apt:
+    name:
+      - ca-certificates
+      - curl
+      - gnupg
+    state: present
+    update_cache: true
+
+- name: Create keyrings directory
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+
+- name: Download Docker GPG key
+  ansible.builtin.get_url:
+    url: https://download.docker.com/linux/ubuntu/gpg
+    dest: /etc/apt/keyrings/docker.asc
+    mode: '0644'
+
+- name: Get dpkg architecture
+  ansible.builtin.command: dpkg --print-architecture
+  register: dpkg_arch
+  changed_when: false
+
+- name: Add Docker repository
+  ansible.builtin.apt_repository:
+    repo: >-
+      deb [arch={{ dpkg_arch.stdout }} signed-by=/etc/apt/keyrings/docker.asc]
+      https://download.docker.com/linux/{{ ansible_facts['distribution'] | lower }}
+      {{ ansible_facts['distribution_release'] }} stable
+    filename: docker
+    state: present
+
+- name: Install Docker
+  ansible.builtin.apt:
+    name:
+      - docker-ce
+      - docker-ce-cli
+      - containerd.io
+      - docker-buildx-plugin
+      - docker-compose-plugin
+    state: present
+    update_cache: true

--- a/.ansible/variables-example.yml
+++ b/.ansible/variables-example.yml
@@ -81,6 +81,7 @@ apt:
   releases:
     brave: true
     code: true
+    docker: true  # Docker Engine and CLI tools (https://docs.docker.com/engine/install/ubuntu/).
     ethereum: true  # For geth, clef, devp2p, abigen, bootnode, evm and rlpdump (ethereum/go-ethereum).
     mega: true  # MEGA CMD and Desktop App (https://mega.io/desktop & https://mega.io/cmd)
     protonvpn: true


### PR DESCRIPTION
## Summary by Sourcery

Add optional Docker Engine installation to the Linux setup playbook via an APT-based task include.

New Features:
- Provide Ansible tasks to add Docker’s official APT repository and install Docker Engine, CLI, containerd, and related plugins on Ubuntu when enabled via variables.

Enhancements:
- Extend the example variables file with a docker release flag to control Docker installation alongside other optional packages.