### PR TITLE
Add erigon and lighthouse to eget packages

### DIFF
--- a/.ansible/playbooks/tasks/eget.yml
+++ b/.ansible/playbooks/tasks/eget.yml
@@ -93,6 +93,9 @@
       jq: >-
         -a {{ 'linux64' if eget_arch == 'x86_64' else 'linux-arm64' if eget_arch == 'arm64' else 'linux-arm' }}
         jqlang/jq
+      lighthouse: >-
+        -a lighthouse -a {{ 'aarch64' if eget_arch == 'arm64' else eget_arch }}
+        -unknown-linux-gnu.tar.gz -a ^.asc sigp/lighthouse
       nethermind: "-a linux-{{ 'x64' if eget_arch == 'x86_64' else 'arm64' }}.zip -a ^.asc NethermindEth/nethermind"
       oyster: "--tag pearl-wallet-v1.0.0 -a .tar.gz --file oyster --to oyster pearl-research-labs/pearl"
       pandoc: "-a linux-{{ 'amd64' if eget_arch == 'x86_64' else 'arm64' }}.tar.gz jgm/pandoc"

--- a/.ansible/playbooks/tasks/eget.yml
+++ b/.ansible/playbooks/tasks/eget.yml
@@ -85,6 +85,7 @@
         -a tar.gz sharkdp/bat
       btop: "-a btop-{{ eget_plain_arch }}-unknown-linux-musl.tar.gz aristocratos/btop"
       duf: "-a linux_{{ eget_arch }}.tar.gz muesli/duf"
+      erigon: "-a linux_{{ 'amd64' if eget_arch == 'x86_64' else 'arm64' }}.tar.gz -a ^amd64v2 erigontech/erigon"
       eza: "-a {{ eget_plain_arch }}-unknown-linux-gnu -a ^no_libgit -a tar.gz eza-community/eza"
       fd: >-
         -a {{ 'aarch64' if eget_arch == 'arm64' else eget_arch }}

--- a/.ansible/variables-example.yml
+++ b/.ansible/variables-example.yml
@@ -152,6 +152,7 @@ eget_packages:
   - eza          # A modern, maintained replacement for 'ls' (eza-community/eza)
   - fd           # A simple, fast and user-friendly alternative to 'find' (sharkdp/fd)
   - jq           # Command-line JSON processor (jqlang/jq)
+  - lighthouse   # Ethereum consensus client in Rust (sigp/lighthouse)
   - nethermind   # A robust execution client for Ethereum node operators (NethermindEth/nethermind)
   - oyster       # Pearl Wallet management (pearl-research-labs/pearl)
   - pandoc       # Universal markup converter (jgm/pandoc)

--- a/.ansible/variables-example.yml
+++ b/.ansible/variables-example.yml
@@ -148,6 +148,7 @@ eget_packages:
   - bat          # A cat(1) clone with wings (sharkdp/bat)
   - btop         # Resource monitor that shows usage and stats (aristocratos/btop)
   - duf          # Disk Usage/Free Utility - a better 'df' (muesli/duf)
+  - erigon       # Ethereum execution client on the efficiency frontier (erigontech/erigon)
   - eza          # A modern, maintained replacement for 'ls' (eza-community/eza)
   - fd           # A simple, fast and user-friendly alternative to 'find' (sharkdp/fd)
   - jq           # Command-line JSON processor (jqlang/jq)


### PR DESCRIPTION
## Summary by Sourcery

Add additional Ethereum client binaries to the Ansible-managed eget package set.

New Features:
- Add erigon Ethereum execution client to the configurable eget packages.
- Add lighthouse Ethereum consensus client to the configurable eget packages.

Documentation:
- Document erigon and lighthouse in the example eget_packages list with brief descriptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for installing additional packages for Ethereum clients, including `erigon` and `lighthouse`.
  * Expanded platform-specific package selection for several tools, improving availability across architectures.

* **Chores**
  * Updated example configuration so the new package options appear in the default package list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->