### PR TITLE
Add Keybase installation tasks

### DIFF
--- a/.ansible/playbooks/setup-linux.yml
+++ b/.ansible/playbooks/setup-linux.yml
@@ -57,6 +57,12 @@
       become: true
       tags: [apt, protonvpn, vpn]
 
+    - name: Import Keybase installation tasks
+      ansible.builtin.import_tasks: tasks/apt-release-keybase.yml
+      when: (apt.releases.keybase | default(false)) if apt.releases is defined else false
+      become: true
+      tags: [apt, keybase]
+
     - name: Import MEGA installation tasks
       ansible.builtin.import_tasks: tasks/apt-release-mega.yml
       when: apt.releases is defined and (apt.releases.mega | default(false))

--- a/.ansible/playbooks/tasks/apt-release-keybase.yml
+++ b/.ansible/playbooks/tasks/apt-release-keybase.yml
@@ -1,0 +1,8 @@
+---
+- name: Install Keybase
+  ansible.builtin.apt:
+    deb: >-
+      https://prerelease.keybase.io/keybase_{{
+      'amd64' if ansible_facts['architecture'] == 'x86_64' else 'i386'
+      }}.deb
+    state: present

--- a/.ansible/variables-example.yml
+++ b/.ansible/variables-example.yml
@@ -86,6 +86,7 @@ apt:
     code: true
     docker: true  # Docker Engine and CLI tools (https://docs.docker.com/engine/install/ubuntu/).
     ethereum: true  # For geth, clef, devp2p, abigen, bootnode, evm and rlpdump (ethereum/go-ethereum).
+    keybase: true  # Keybase app (https://keybase.io/).
     mega: true  # MEGA CMD and Desktop App (https://mega.io/desktop & https://mega.io/cmd)
     protonvpn: true
   upgrade: true

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -13,3 +13,4 @@
 ^https://dl\.deno\.land/release/
 ^https://github\.com/zyedidia/eget/releases/download/v
 ^https://mega\.nz/linux/repo/xUbuntu_
+^https://prerelease\.keybase\.io/keybase_

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -24,6 +24,9 @@
     },
     {
       "pattern": "^https://github.com/zyedidia/eget/releases/download/v"
+    },
+    {
+      "pattern": "^https://prerelease.keybase.io/keybase_"
     }
   ],
   "retryCount": 3,


### PR DESCRIPTION
## Summary by Sourcery

Add Keybase as an optional APT-installed application in the Linux setup playbook.

New Features:
- Introduce a Keybase installation task using a downloadable .deb package based on system architecture.
- Add a configuration flag to enable or disable Keybase installation in the example variables file.