### PR TITLE
Add node to eget_packages and define nodejs_version

### DIFF
--- a/.ansible/playbooks/tasks/eget.yml
+++ b/.ansible/playbooks/tasks/eget.yml
@@ -97,6 +97,13 @@
         -a lighthouse -a {{ 'aarch64' if eget_arch == 'arm64' else eget_arch }}
         -unknown-linux-gnu.tar.gz -a ^.asc sigp/lighthouse
       nethermind: "-a linux-{{ 'x64' if eget_arch == 'x86_64' else 'arm64' }}.zip -a ^.asc NethermindEth/nethermind"
+      node: >-
+        --file '*/bin/node' --to node
+        https://nodejs.org/dist/{{ nodejs_version | default('v24.18.0') }}/node-{{ nodejs_version | default('v24.18.0') }}-linux-{{
+          'x64' if eget_arch == 'x86_64'
+          else 'arm64' if eget_arch == 'arm64'
+          else 'armv7l'
+        }}.tar.xz
       oyster: "--tag pearl-wallet-v1.0.0 -a .tar.gz --file oyster --to oyster pearl-research-labs/pearl"
       pandoc: "-a linux-{{ 'amd64' if eget_arch == 'x86_64' else 'arm64' }}.tar.gz jgm/pandoc"
       pearld: "--tag pearl-wallet-v1.0.0 -a .tar.gz --file pearld --to pearld pearl-research-labs/pearl"

--- a/.ansible/variables-example.yml
+++ b/.ansible/variables-example.yml
@@ -55,8 +55,6 @@ apt:
     - moreutils  # Additional Unix utilities (e.g. pee, sponge).
     - mpv  # Cross-platform media player for the command line.
     - net-tools  # ifconfig
-    - nodejs
-    - npm
     - nvidia-vaapi-driver  # A VA-API implemention using NVIDIA's NVDEC.
     - nvitop
     - nvtop
@@ -166,6 +164,7 @@ eget_packages:
   - jq           # Command-line JSON processor (jqlang/jq)
   - lighthouse   # Ethereum consensus client in Rust (sigp/lighthouse)
   - nethermind   # A robust execution client for Ethereum node operators (NethermindEth/nethermind)
+  - node         # JavaScript runtime built on Chrome's V8 JavaScript engine (nodejs/node)
   - oyster       # Pearl Wallet management (pearl-research-labs/pearl)
   - pandoc       # Universal markup converter (jgm/pandoc)
   - pearld       # Pearl Full node (pearl-research-labs/pearl)
@@ -177,6 +176,8 @@ eget_packages:
   - vale         # A syntax-aware linter for prose (errata-ai/vale)
   - yq           # Portable command-line YAML, JSON, XML, CSV, TOML and properties processor (mikefarah/yq)
   - yt-dlp       # A feature-rich command-line audio/video downloader (yt-dlp/yt-dlp)
+
+nodejs_version: v24.18.0
 
 nvidia:
   cuda_toolkit: true


### PR DESCRIPTION
## Summary by Sourcery

Provision Node.js as a version-controlled eget package across supported architectures.

New Features:
- Install Node.js through eget with architecture-aware downloads and configurable version selection.

Enhancements:
- Move Node.js and npm provisioning from apt packages to the managed eget package list.