### PR TITLE
Add claude to eget_packages for Claude Code CLI tool

### DIFF
--- a/.ansible/playbooks/tasks/eget.yml
+++ b/.ansible/playbooks/tasks/eget.yml
@@ -91,6 +91,8 @@
           else 'arm'
         }}-linux-gnu.tar.gz
       btop: "-a btop-{{ eget_plain_arch }}-unknown-linux-musl.tar.gz aristocratos/btop"
+      claude: >-
+        --to claude https://downloads.claude.ai/claude-code-releases/$(curl -s https://downloads.claude.ai/claude-code-releases/latest)/{{ 'linux-musl' if eget_arch == 'x86_64' and ansible_facts['os_family'] == 'Alpine' else 'linux' }}-{{ 'x64' if eget_arch == 'x86_64' else 'arm64' if eget_arch == 'arm64' else 'arm' }}/claude
       duf: "-a linux_{{ eget_arch }}.tar.gz muesli/duf"
       erigon: "-a linux_{{ 'amd64' if eget_arch == 'x86_64' else 'arm64' }}.tar.gz -a ^amd64v2 erigontech/erigon"
       eza: "-a {{ eget_plain_arch }}-unknown-linux-gnu -a ^no_libgit -a tar.gz eza-community/eza"

--- a/.ansible/variables-example.yml
+++ b/.ansible/variables-example.yml
@@ -159,6 +159,7 @@ eget_packages:
   - bat          # A cat(1) clone with wings (sharkdp/bat)
   - bitcoind     # Bitcoin Core full node (bitcoin/bitcoin)
   - btop         # Resource monitor that shows usage and stats (aristocratos/btop)
+  - claude       # Claude Code CLI tool (Anthropic)
   - duf          # Disk Usage/Free Utility - a better 'df' (muesli/duf)
   - erigon       # Ethereum execution client on the efficiency frontier (erigontech/erigon)
   - eza          # A modern, maintained replacement for 'ls' (eza-community/eza)


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Add the Claude Code CLI tool to the managed eget package collection across supported Linux architectures and Alpine environments.