### PR TITLE
Add ollama to eget packages

### DIFF
--- a/.ansible/playbooks/tasks/eget.yml
+++ b/.ansible/playbooks/tasks/eget.yml
@@ -113,6 +113,7 @@
           else 'arm64' if eget_arch == 'arm64'
           else 'armv7l'
         }}.tar.xz
+      ollama: "-a ollama-linux-{{ 'amd64' if eget_arch == 'x86_64' else 'arm64' }}.tar.zst -a ^mlx -a ^rocm ollama/ollama"
       oyster: "--tag pearl-wallet-v1.0.0 -a .tar.gz --file oyster --to oyster pearl-research-labs/pearl"
       pandoc: "-a linux-{{ 'amd64' if eget_arch == 'x86_64' else 'arm64' }}.tar.gz jgm/pandoc"
       pearld: "--tag pearl-wallet-v1.0.0 -a .tar.gz --file pearld --to pearld pearl-research-labs/pearl"

--- a/.ansible/variables-example.yml
+++ b/.ansible/variables-example.yml
@@ -168,6 +168,7 @@ eget_packages:
   - lighthouse   # Ethereum consensus client in Rust (sigp/lighthouse)
   - nethermind   # A robust execution client for Ethereum node operators (NethermindEth/nethermind)
   - node         # JavaScript runtime built on Chrome's V8 JavaScript engine (nodejs/node)
+  - ollama       # Run large language models locally (ollama/ollama)
   - oyster       # Pearl Wallet management (pearl-research-labs/pearl)
   - pandoc       # Universal markup converter (jgm/pandoc)
   - pearld       # Pearl Full node (pearl-research-labs/pearl)

--- a/.ansible/variables-example.yml
+++ b/.ansible/variables-example.yml
@@ -41,8 +41,10 @@ apt:
     - libcurl4-openssl-dev
     - libdb5.3++-dev  # Headers and static libraries for the Berkeley v5.3 database library.
     - libhyperscan-dev
-    - libicu-dev
+    - libicu-dev 
     - libleveldb-dev  # Fast key-value storage library (development files).
+    - libnccl-dev  # NVIDIA Collective Communication Library (NCCL) Development Files. Recommended for llama.
+    - libnccl2  # Library of standard collective communication routines for GPUs. Recommended for llama.
     - libopenblas-dev  # BLAS library. Recommended for llama.
     - libpcre2-dev
     - libpcre3-dev

--- a/.ansible/variables-example.yml
+++ b/.ansible/variables-example.yml
@@ -11,6 +11,7 @@ apt:
     - athena-jot  # Print sequential or random data.
     - btrfs-progs
     - build-essential
+    - ccache  # Compiler cache for fast recompilation of C/C++ code. Recommended for llama.
     - cargo
     - cifs-utils  # The SMB/CIFS protocol for cross-platform file sharing.
     - coreutils
@@ -42,6 +43,7 @@ apt:
     - libhyperscan-dev
     - libicu-dev
     - libleveldb-dev  # Fast key-value storage library (development files).
+    - libopenblas-dev  # BLAS library. Recommended for llama.
     - libpcre2-dev
     - libpcre3-dev
     - libssl-dev


### PR DESCRIPTION
## Summary by Sourcery

Add Ollama and its recommended runtime dependencies to the package configuration.

New Features:
- Add Ollama to the managed eget package set for supported Linux architectures.

Enhancements:
- Add recommended compiler and GPU acceleration dependencies for local Llama workloads.